### PR TITLE
upgraded list_objects and implemented disk usage

### DIFF
--- a/rda_s3/rda_s3.py
+++ b/rda_s3/rda_s3.py
@@ -29,6 +29,7 @@ import sys
 import os
 import argparse
 import json
+import re
 import boto3
 import logging
 
@@ -199,7 +200,7 @@ def list_buckets(buckets_only=False):
 def list_objects(bucket, glob=None, ls=False, keys_only=False):
     """Lists objects from a bucket, optionally matching _glob.
 
-    _glob should be heavily preferred.
+    glob should be heavily preferred.
 
     Args:
         bucket (str): Name of s3 bucket.
@@ -227,9 +228,34 @@ def list_objects(bucket, glob=None, ls=False, keys_only=False):
     else:
         response = client.list_objects_v2(Bucket=bucket, Prefix=glob)
 
+    if 'Contents' not in response:
+        return []
     if keys_only:
         return list(map(lambda x: x['Key'], response['Contents']))
     return response['Contents']
+
+def regex_filter(contents, regex_str):
+    """Filters contents using regular expression.
+
+    Args:
+        contents (list): response 'Contents' objects
+        regex_str (str): regular expression string
+
+    Returns:
+        (list) Contents objects.
+
+    """
+    filtered_objects = []
+    regex = re.compile(regex_str)
+    for _object in contents:
+        match = regex.match(_object['Key'])
+        if match is not None:
+            filtered_objects.append(_object)
+
+    return filtered_objects
+
+
+
 
 def get_metadata(bucket, key):
     """Gets metadata of a given object key.


### PR DESCRIPTION
The new list_objects will be able to handle >1000 objects. 
Also added regular expression filter. 
For example, to only get netCDF files from a dataset, it might look something like this:
`./rda_s3.py lo -b mybucket -re ".*nc$" ds633.0`

We may want to change this so it automatically adds '.*' around the string if necessary, so the regex could just be `nc$`. Or something like `TMP` without having to do '.*TMP.*'. Anyway, it's worth considering. 

Additionally, disk usage has been completed. Examples include:
```
./rda_s3.py du -b mybucket --block_size 500MB # This would get full size of bucket in 500mb blocks
./rda_s3.py du -b mybucket -re '.*grb2'  # This would get size of all grb2 files in 1KB blocks (defualt)
./rda_s3.py du -b mybucket ds084.1 # This would get the size of ds084.1
```

resolves #10 
resolves #8 