### PR TITLE
Update python3

### DIFF
--- a/rda_s3/rda_s3.py
+++ b/rda_s3/rda_s3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Interacts with s3 api
 
 Usage:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ if sys.version_info < (3, 1):
     raise NotImplementedError(
         """\n
 ##############################################################
-# rda-s3 does not support python versions older than 3.0 #
+# rda-s3 does not support python versions older than 3.1 #
 ##############################################################"""
     )
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Test rda_s3.py
 """


### PR DESCRIPTION
Updated python interpreter to /usr/bin/env python3.  This is needed because the default python interpreter on the rda VMs is python2.